### PR TITLE
21024: Upgrades GDB/Ubuntu versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
   test:
     name: Fuzz tests (${{ matrix.amlg-postfix }})
     needs: ["metadata"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -90,12 +90,6 @@ jobs:
         sudo apt-get install -y gdb
 
         echo "GDB installation complete"
-        gdb --version
-
-        echo "Checking for updates..."
-        sudo apt-get update
-        sudo apt-get upgrade gdb
-
         gdb --version
 
         # Don't immediately fail if GDB exits with a non-zero code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,15 @@ jobs:
       run: |
         # Install GDB
         sudo apt-get install -y gdb
+
         echo "GDB installation complete"
+        gdb --version
+
+        echo "Checking for updates..."
+        sudo apt-get update
+        sudo apt-get upgrade gdb
+
+        gdb --version
 
         # Don't immediately fail if GDB exits with a non-zero code
         set +e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,6 @@ jobs:
       run: |
         # Install GDB
         sudo apt-get install -y gdb
-
         echo "GDB installation complete"
         gdb --version
 


### PR DESCRIPTION
There is a [bug](https://sourceware.org/bugzilla/show_bug.cgi?id=29185) in older versions of GDB that has been causing pipeline failures. To upgrade GDB to a newer version, we must also upgrade Ubuntu to the newest version GitHub offers as a runner image, `24.04`.