### PR TITLE
21162: Refactors timeout implementation to print stack traces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,9 +99,31 @@ jobs:
         echo "Note: output is supressed due to length. See build artifacts for full logs."
         echo "Running..."
 
-        # Capture GDB output (15 minute timeout)
-        gdb_output=$(timeout 900 gdb -batch -ex run -ex backtrace --args ./amalgam${{ matrix.amlg-postfix }} --debug-internal-memory tic_tac_toe_evolver.amlg -target-time 300)
+        # Run Evolver with GDB
+        # However, sent a SIGINT after 6 minutes (indicating a hanging Evolver) to get a stacktrace
+        TIMEOUT=360
+
+        # Run GDB in the background
+        gdb_output_file=$(mktemp)
+        if [[ "${{ matrix.amlg-postfix }}" == *"mt"* ]]; then
+          gdb -batch -ex run -ex "thread apply all bt" --args ./amalgam${{ matrix.amlg-postfix }} --debug-internal-memory tic_tac_toe_evolver.amlg -target-time 300 > "$gdb_output_file" 2>&1 &
+          GDB_PID=$!
+        else
+          gdb -batch -ex run -ex bt --args ./amalgam${{ matrix.amlg-postfix }} --debug-internal-memory tic_tac_toe_evolver.amlg -target-time 300 > "$gdb_output_file" 2>&1 &
+          GDB_PID=$!
+        fi
+
+        echo "GDB PID: $GDB_PID"
+
+        # Set up a timer to send SIGINT to GDB after the timeout
+        {
+            sleep $TIMEOUT
+            kill -SIGINT $GDB_PID
+        } &
+        wait $GDB_PID
         gdb_exit_code=$?
+        gdb_output=$(cat "$gdb_output_file")
+        # Save output to logs.txt, uploaded later
         echo "$gdb_output" >> logs.txt
 
         # Evaluate GDB exit code and exit this workflow accordingly
@@ -117,7 +139,7 @@ jobs:
           fi
         else
           # If GDB exited with code 0, there was a segfault
-          echo "$gdb_output" | tail -n 200
+          echo "$gdb_output" | tail -n 400
           exit 139
         fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amlg-postfix: ['-st', '-mt-afmi']
+        amlg-postfix: ['-st-afmi', '-mt-afmi']
 
     steps:
 
@@ -121,26 +121,20 @@ jobs:
             kill -SIGINT $GDB_PID
         } &
         wait $GDB_PID
-        gdb_exit_code=$?
         gdb_output=$(cat "$gdb_output_file")
+
         # Save output to logs.txt, uploaded later
         echo "$gdb_output" >> logs.txt
 
+        # Print a reasonable amount of the logs to the console
+        echo "$gdb_output" | tail -n 400
+
         # Evaluate GDB exit code and exit this workflow accordingly
-        if [[ $gdb_exit_code -ne 0 ]]; then
-          echo "GDB has exited"
-          echo "$gdb_output" | tail -n 6
-          # If GDB exited with an error but the test process passed, exit 0
-          if echo "$gdb_output" | tail -n 6 | grep -q "exited normally"; then
-            exit 0
-          # Else, the test process failed, exit 1
-          else
-            exit 1
-          fi
+        if echo "$gdb_output" | tail -n 100 | grep -q "exited normally"; then
+          exit 0
+        # Else, something failed, exit 1
         else
-          # If GDB exited with code 0, there was a segfault
-          echo "$gdb_output" | tail -n 400
-          exit 139
+          exit 1
         fi
 
     - name: Compress 'evolve' directory

--- a/tic_tac_toe_evolver.amlg
+++ b/tic_tac_toe_evolver.amlg
@@ -42,10 +42,19 @@
 					board board
 					player player
 					)
+					;total number of execution cycles
 					2000
 					;count the entity size toward total memory allowed to be used
 					(- 2000 (total_entity_size entity))
-					200)
+					;limit stack depth to something reasonable
+					200
+					;maximum contained entities
+					5
+					;maximum entity depth
+					3
+					;max entity name length
+					25
+					)
 				
 		#get_player_1_move
 			(call_container "^get_move_from_entity" (assoc


### PR DESCRIPTION
When the timeout is reached, a SIGINT is sent to GDB that will pause the program execution and print a stack trace.

MT also now print the stack traces of all threads.