### PR TITLE
25611: Fix split_diploid_to_2_haploids: clone ploid2 into second haploid

### DIFF
--- a/evolver.amlg
+++ b/evolver.amlg
@@ -483,7 +483,7 @@
 				)
 			(list
 				(clone_entities (list diploid "ploid1") id1)
-				(clone_entities (list diploid "ploid1") id2)
+				(clone_entities (list diploid "ploid2") id2)
 			)
 		)
 


### PR DESCRIPTION
## Summary
- `split_diploid_to_2_haploids` cloned `ploid1` into both offspring; `ploid2` was never used (one chromosome dropped). Second clone now sources `ploid2`, mirroring `blend_2_haploids_to_diploid`.
- Latent: the label is currently uncalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)